### PR TITLE
don't pass field_name when using get_css() and get_xpath()

### DIFF
--- a/scrapy_loader_upkeep/loader.py
+++ b/scrapy_loader_upkeep/loader.py
@@ -43,7 +43,7 @@ class ItemLoader(ItemLoaderOG):
         self.replace_value(field_name, values, *processors, **kw)
 
     def get_xpath(self, xpath, *processors, **kw):
-        values = self._get_xpathvalues(field_name, xpath, **kw)
+        values = self._get_xpathvalues(None, xpath, **kw)
         return self.get_value(values, *processors, **kw)
 
     def add_css(self, field_name, css, *processors, **kw):
@@ -56,7 +56,7 @@ class ItemLoader(ItemLoaderOG):
         self.replace_value(field_name, values, *processors, **kw)
 
     def get_css(self, css, *processors, **kw):
-        values = self._get_cssvalues(field_name, css, **kw)
+        values = self._get_cssvalues(None, css, **kw)
         return self.get_value(values, *processors, **kw)
 
     # The methods below are overridden and have been refactored for integration
@@ -104,7 +104,7 @@ class ItemLoader(ItemLoaderOG):
         '*/missing' in the stats.
         """
 
-        if not self.stats:
+        if not self.stats or not field_name:
             return
 
         parser_label = (

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -81,6 +81,16 @@ def test_write_to_stats_with_no_parsed_data():
     loader.stats.inc_value.assert_called_once_with(expected_stat_key)
 
 
+def test_write_to_stats_with_no_field_name():
+    """It should not call stats when the 'field_name' passed is None."""
+
+    loader = ItemLoader()
+    loader.stats = mock.Mock()
+
+    assert loader.write_to_stats(None, "sample data", 0, "css") == None
+    loader.stats.inc_value.assert_not_called()
+
+
 def test_write_to_stats():
     """It should incremenent the correct key in the stat."""
 


### PR DESCRIPTION
Fixes this type of error when using `get_css()` and `get_xpath()` since they don't use field names as inputs.

```
File "/app/python/lib/python3.6/site-packages/scrapy_loader_upkeep/loader.py", line 46, in get_xpath
    values = self._get_xpathvalues(field_name, xpath, **kw)
NameError: name 'field_name' is not defined
```

This change will have `write_to_stats()` not increment any stats when the **field_name** is `None`.